### PR TITLE
fix: node cache version to v4

### DIFF
--- a/.github/workflows/main-e2e.yml
+++ b/.github/workflows/main-e2e.yml
@@ -27,7 +27,7 @@ jobs:
       # We are cache-ing our node modules to slightly speed up execution in the future.
       - name: Cache node modules
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
Node cache needed to be updated as it still depends on Node 16.