### PR TITLE
fix: remove idp tests from main regression test

### DIFF
--- a/.github/workflows/main-e2e.yml
+++ b/.github/workflows/main-e2e.yml
@@ -192,22 +192,6 @@ jobs:
           # project: ./e2e
           ci-build-id: ${{ github.event.number }}
 
-      - name: IDP Stopper
-        uses: cypress-io/github-action@v6
-        id: IDP-stopper
-        continue-on-error: false
-        with:
-          summary-title: 'IDP Stopper Tests'
-          wait-on: ${{ secrets.CYPRESS_HOST }}
-          wait-on-timeout: 120
-          record: true
-          install-command: npm ci
-          working-directory: testing
-          spec: |
-            cypress/e2e/**/idpstopper-*-*.cy.ts
-          browser: chrome
-          ci-build-id: ${{ github.event.number }}
-
       - name: Run the reports
         run: |
           cd testing


### PR DESCRIPTION
With the instability of the IDP Tests, we cannot really depend on them when they are part of the main regression test. Therefore we'll remove them from the main-e2e workflow.