### PR TITLE
chore: skip delete

### DIFF
--- a/testing/cypress/appActions/Request.ts
+++ b/testing/cypress/appActions/Request.ts
@@ -500,6 +500,16 @@ class Request {
 
   deleteAllRequests() {
     cy.visit(this.reqPage.path);
+
+    // Ignore deletion if there is no request table
+    let hasRequests = false;
+    cy.get('body').then((bodyElement) => {
+      if (bodyElement.find('table').length > 0) {
+        hasRequests = true;
+      }
+    });
+    if (!hasRequests) return;
+
     // identify first column
     cy.get(this.reqPage.integrationsTableName).each(($elm, index) => {
       // text captured from column1
@@ -1100,6 +1110,7 @@ class Request {
             force: true,
           })
           .trigger('input');
+        cy.contains('.select-inner__menu', 'pathfinder.ssotraining2@gov.bc.ca').click();
         cy.get(this.teamPage.userRole).eq(0).select('Admin');
         cy.get('[data-testid="send-invitation"]').click({ force: true });
       });

--- a/testing/cypress/pageObjects/teamPage.ts
+++ b/testing/cypress/pageObjects/teamPage.ts
@@ -18,7 +18,7 @@ class TeamPage {
   modalDeleteMember: string = '#delete-member-modal';
   deleteUser: string = '[data-testid="delete-user-role"]';
   addUser: string = '[data-testid="add-user-role"]';
-  userEmail: string = '[data-testid="user-email"]';
+  userEmail: string = 'input.select-inner__input';
   userRole: string = '[data-testid="user-role"]';
   deleteUserRole: string = '[data-testid="delete-user-role"]';
   editTeamName: string = '[data-testid="edit-name"]';


### PR DESCRIPTION
These are two small changes I needed while reviewing 1525 to run the smoke suite:
- skip deletion if no requests for user
- Update to IDIR email select

I wanted to add a testid to the new component, but I don't think that react-select exposes a prop to put an arbitrary attribute on the select so I had to change the selector. 
