### PR TITLE
chore: reorganize main e2e tests

### DIFF
--- a/.github/workflows/full-regression.yml
+++ b/.github/workflows/full-regression.yml
@@ -1,0 +1,380 @@
+name: full-regression
+
+on:
+  workflow_dispatch:
+    inputs:
+      smoketest:
+        required: true
+        description: 'Is this a smoke test?'
+        default: 'false'
+      localtest:
+        required: true
+        description: 'Is this a local test?'
+        default: 'false'
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
+env:
+  CYPRESS_users: ${{ secrets.CYPRESS_USERS }}
+  CYPRESS_BASE_URL: ${{ secrets.CYPRESS_BASEURL }}
+  CYPRESS_host: ${{ secrets.CYPRESS_HOST }}
+  CYPRESS_guid: ${{ secrets.CYPRESS_GUID }}
+  CYPRESS_ENVIRONMENT: ${{ github.base_ref }}
+  CYPRESS_loginproxy: ${{ secrets.CYPRESS_LOGINPROXY }}
+  CYPRESS_siteminder: ${{ secrets.CYPRESS_SITEMINDER }}
+  CYPRESS_smoketest: ${{inputs.smoketest}}
+  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  pre-reqs:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
+    steps:
+      # Checkout the PR branch
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+
+      - name: Pre-requisites for test run
+        uses: cypress-io/github-action@v6
+        id: prereq
+        continue-on-error: false
+        with:
+          summary-title: 'Pre-reqs'
+          wait-on: ${{ secrets.CYPRESS_HOST }}
+          wait-on-timeout: 120
+          record: true
+          install-command: npm ci
+          working-directory: testing
+          spec: |
+            cypress/e2e/**/integration-990-deleteAllIntegrations.cy.ts
+            cypress/e2e/**/team-900-*.cy.ts
+            cypress/e2e/**/prereq.cy.ts
+          browser: chrome
+          # project: ./e2e
+          ci-build-id: ${{ github.event.number }}
+
+      - name: Run the reports
+        run: |
+          cd testing
+          npm run report
+
+      - name: Upload Test Reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: pre-req-results
+          path: testing/mochawesome-report/report.html
+
+  smoke-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
+    steps:
+      # Checkout the PR branch
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+      - name: E2E Smoke tests
+        uses: cypress-io/github-action@v6
+        id: smoke
+        continue-on-error: false
+        with:
+          summary-title: 'E2E Smoke tests'
+          wait-on: ${{ secrets.CYPRESS_HOST }}
+          wait-on-timeout: 120
+          record: true
+          install-command: npm ci
+          working-directory: testing
+          spec: |
+            cypress/e2e/smoke/smoke-*-*.cy.ts
+          browser: chrome
+          # project: ./e2e
+          ci-build-id: ${{ github.event.number }}
+
+      - name: Run the reports
+        run: |
+          cd testing
+          npm run report
+
+      - name: Upload Test Reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-results
+          path: testing/mochawesome-report/report.html
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: [pre-reqs, smoke-test]
+    strategy:
+      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
+    steps:
+      # Checkout the PR branch
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+
+      - name: Request Creation tests
+        uses: cypress-io/github-action@v6
+        id: integration-requests-tests
+        continue-on-error: false
+        with:
+          summary-title: 'Request Integration tests'
+          wait-on: ${{ secrets.CYPRESS_HOST }}
+          wait-on-timeout: 120
+          record: true
+          install-command: npm ci
+          working-directory: testing
+          spec: |
+            cypress/e2e/**/integration-010-*.cy.ts
+            cypress/e2e/**/integration-011-*.cy.ts
+            cypress/e2e/**/integration-012-*.cy.ts
+            cypress/e2e/**/integration-013-*.cy.ts
+            cypress/e2e/**/integration-900-*.cy.ts
+          browser: chrome
+          # project: ./e2e
+          ci-build-id: ${{ github.event.number }}
+
+      - name: Run the reports
+        run: |
+          cd testing
+          npm run report
+
+      - name: Upload Test Reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-results
+          path: testing/mochawesome-report/report.html
+
+  roles-tests:
+    runs-on: ubuntu-latest
+    needs: [integration-tests]
+    strategy:
+      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
+    steps:
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+
+      - name: Roles tests
+        uses: cypress-io/github-action@v6
+        id: roles-tests
+        continue-on-error: false
+        with:
+          summary-title: 'Roles tests'
+          wait-on: ${{ secrets.CYPRESS_HOST }}
+          wait-on-timeout: 120
+          record: true
+          install-command: npm ci
+          working-directory: testing
+          spec: |
+            cypress/e2e/**/integration-040-*.cy.ts
+            cypress/e2e/**/integration-041-*.cy.ts
+            cypress/e2e/**/integration-042-*.cy.ts
+            cypress/e2e/**/integration-043-*.cy.ts
+            cypress/e2e/**/integration-044-*.cy.ts
+            cypress/e2e/**/integration-910-deleteIntegrationRoles.cy.ts
+          browser: chrome
+          # project: ./e2e
+          ci-build-id: ${{ github.event.number }}
+
+      - name: Run the reports
+        run: |
+          cd testing
+          npm run report
+
+      - name: Upload Test Reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: roles-test-results
+          path: testing/mochawesome-report/report.html
+
+  sso:
+    runs-on: ubuntu-latest
+    needs: [roles-tests]
+    strategy:
+      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
+    steps:
+      # Checkout the PR branch
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+      - name: SSO Tests
+        uses: cypress-io/github-action@v6
+        id: sso
+        continue-on-error: false
+        with:
+          summary-title: 'SSO Tests'
+          wait-on: ${{ secrets.CYPRESS_HOST }}
+          wait-on-timeout: 120
+          record: true
+          install-command: npm ci
+          working-directory: testing
+          spec: |
+            cypress/e2e/**/sso-020-sessions.cy.ts
+          browser: chrome
+          # project: ./e2e
+          ci-build-id: ${{ github.event.number }}
+
+      - name: Run the reports
+        run: |
+          cd testing
+          npm run report
+
+      - name: Upload Test Reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: sso-results
+          path: testing/mochawesome-report/report.html
+
+  search-tests:
+    runs-on: ubuntu-latest
+    needs: [smoke-test, pre-reqs]
+    strategy:
+      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
+    steps:
+      # Checkout the PR branch
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+      - name: Search Users
+        uses: cypress-io/github-action@v6
+        id: search-users
+        continue-on-error: false
+        with:
+          summary-title: 'Search Users tests'
+          wait-on: ${{ secrets.CYPRESS_HOST }}
+          wait-on-timeout: 120
+          record: true
+          install-command: npm ci
+          working-directory: testing
+          spec: |
+            cypress/e2e/**/search-010-rolesUsers.cy.ts
+            cypress/e2e/**/search-020-IDIM.cy.ts
+          browser: chrome
+          # project: ./e2e
+          ci-build-id: ${{ github.event.number }}
+
+      - name: Run the reports
+        run: |
+          cd testing
+          npm run report
+
+      - name: Upload Test Reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: search-test-results
+          path: testing/mochawesome-report/report.html
+
+  team-tests:
+    runs-on: ubuntu-latest
+    needs: [search-tests]
+    strategy:
+      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
+    steps:
+      # Checkout the PR branch
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+      - name: Team Tests
+        uses: cypress-io/github-action@v6
+        id: teams
+        continue-on-error: false
+        with:
+          summary-title: 'Team tests'
+          wait-on: ${{ secrets.CYPRESS_HOST }}
+          wait-on-timeout: 120
+          record: true
+          install-command: npm ci
+          working-directory: testing
+          spec: |
+            cypress/e2e/**/team-020-**.cy.ts
+            cypress/e2e/**/team-030-**.cy.ts
+          browser: chrome
+          # project: ./e2e
+          ci-build-id: ${{ github.event.number }}
+
+      - name: Run the reports
+        run: |
+          cd testing
+          npm run report
+
+      - name: Upload Test Reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: team-test-results
+          path: testing/mochawesome-report/report.html
+
+  idpstopper-tests:
+    runs-on: ubuntu-latest
+    needs: [team-tests]
+    strategy:
+      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
+    steps:
+      # Checkout the PR branch
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+      - name: IDP Stoppers
+        uses: cypress-io/github-action@v6
+        id: idpstop
+        continue-on-error: false
+        with:
+          summary-title: 'IDP Stopper tests'
+          wait-on: ${{ secrets.CYPRESS_HOST }}
+          wait-on-timeout: 120
+          record: true
+          install-command: npm ci
+          working-directory: testing
+          spec: |
+            cypress/e2e/**/idpstopper-**-**.cy.ts
+          browser: chrome
+          # project: ./e2e
+          ci-build-id: ${{ github.event.number }}
+
+      - name: Run the reports
+        run: |
+          cd testing
+          npm run report
+
+      - name: Upload Test Reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: idp-stopper-test-results
+          path: testing/mochawesome-report/report.html
+
+  all-delete:
+    runs-on: ubuntu-latest
+    needs: [team-tests]
+    strategy:
+      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
+    steps:
+      # Checkout the PR branch
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+      - name: Teams Delete
+        uses: cypress-io/github-action@v6
+        id: teamsdelete
+        continue-on-error: false
+        with:
+          summary-title: 'Delete Teams and Integration'
+          wait-on: ${{ secrets.CYPRESS_HOST }}
+          wait-on-timeout: 120
+          record: true
+          install-command: npm ci
+          working-directory: testing
+          spec: |
+            cypress/e2e/**/integration-990-deleteAllIntegrations.cy.ts
+            cypress/e2e/**/team-900-*.cy.ts
+          browser: chrome
+          # project: ./e2e
+          ci-build-id: ${{ github.event.number }}
+
+      - name: Run the reports
+        run: |
+          cd testing
+          npm run report
+
+      - name: Upload Test Reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: all-delete-results
+          path: testing/mochawesome-report/report.html

--- a/.github/workflows/main-e2e.yml
+++ b/.github/workflows/main-e2e.yml
@@ -357,7 +357,7 @@ jobs:
 
   search-tests:
     runs-on: ubuntu-latest
-    needs: [pre-reqs, smoke-test]
+    needs: [smoke-test]
     strategy:
       fail-fast: false # https://github.com/cypress-io/github-action/issues/48
     steps:

--- a/.github/workflows/main-e2e.yml
+++ b/.github/workflows/main-e2e.yml
@@ -149,6 +149,7 @@ jobs:
           spec: |
             cypress/e2e/**/integration-010-*.cy.ts
             cypress/e2e/**/integration-040-*.cy.ts
+            cypress/e2e/**/team-001-**.cy.ts
             cypress/e2e/**/sso-010-createIntegration.cy.ts
           browser: chrome
           # project: ./e2e
@@ -404,7 +405,7 @@ jobs:
 
   team-tests:
     runs-on: ubuntu-latest
-    needs: [pre-reqs, smoke-test]
+    needs: [pre-reqs, create-integrations]
     strategy:
       fail-fast: false # https://github.com/cypress-io/github-action/issues/48
     steps:
@@ -423,7 +424,6 @@ jobs:
           install-command: npm ci
           working-directory: testing
           spec: |
-            cypress/e2e/**/team-001-**.cy.ts
             cypress/e2e/**/team-020-**.cy.ts
             cypress/e2e/**/team-030-**.cy.ts
           browser: chrome

--- a/testing/cypress.config.ts
+++ b/testing/cypress.config.ts
@@ -35,11 +35,11 @@ export default defineConfig({
         },
       });
       on('before:browser:launch', (browser, launchOptions) => {
-        if (browser.name === 'chrome') {
-          // exposes window.gc() function that will manually force garbage collection
+        if (browser.family === 'chromium' && (browser.name === 'chrome' || browser.name === 'chromium')) {
+          // If the browser is Chrome or Chromium, add the flags to expose the `gc` function and disable GPU
           launchOptions.args.push('--js-flags=--expose-gc');
+          launchOptions.args.push('--disable-gpu');
         }
-
         return launchOptions;
       });
     },

--- a/testing/cypress/appActions/Request.ts
+++ b/testing/cypress/appActions/Request.ts
@@ -194,7 +194,9 @@ class Request {
     this.reqPage.pageNext();
 
     this.reqPage.submitRequest(this.subMit);
+    cy.wait(3000);
     this.reqPage.confirmDelete(this.conFirm);
+    cy.wait(3000);
 
     // Navigate to the page if not there already (e.g for admins)
     cy.visit(this.reqPage.path);

--- a/testing/cypress/appActions/Request.ts
+++ b/testing/cypress/appActions/Request.ts
@@ -228,19 +228,14 @@ class Request {
     let n = 0;
     cy.log('Validate Request: ' + id);
     cy.visit(this.reqPage.path);
-    // identify first column
-    cy.contains('td', id).scrollIntoView();
-    cy.get(this.reqPage.integrationsTable).each(($elm, index, $list) => {
-      // text captured from column1
-      let t = $elm.text();
-      // matching criteria
-      if (t.includes(id)) {
-        cy.contains('td', id).scrollIntoView();
-        cy.get(this.reqPage.integrationsTable).eq(index).scrollIntoView();
-        cy.get(this.reqPage.editButton).eq(index).click({ force: true });
-        cy.log(index.toString());
-      }
-    });
+
+    cy.contains('td', id, { timeout: 10000 })
+      .parent()
+      .click()
+      .scrollIntoView()
+      .within(() => {
+        cy.get(this.reqPage.editButton).click({ force: true });
+      });
 
     // Goto the preview tab
     cy.get(this.reqPage.prev_Tab).click();
@@ -354,17 +349,14 @@ class Request {
   updateRequest(id: string): boolean {
     cy.log('Update Request: ' + id);
     cy.visit(this.reqPage.path);
-    // identify first column
-    cy.get(this.reqPage.integrationsTable).each(($elm, index, $list) => {
-      // text captured from column1
-      let t = $elm.text();
-      // matching criteria
-      if (t.includes(id)) {
-        cy.get(this.reqPage.integrationsTable).eq(index).scrollIntoView();
-        cy.get(this.reqPage.editButton).eq(index).click({ force: true });
-        cy.log(index.toString());
-      }
-    });
+
+    cy.contains('td', id, { timeout: 10000 })
+      .parent()
+      .click()
+      .scrollIntoView()
+      .within(() => {
+        cy.get(this.reqPage.editButton).click({ force: true });
+      });
 
     // Tab 1: Requester Info
     if (this.projectName !== '') {
@@ -586,9 +578,9 @@ class Request {
   addRole(id: string, role: string, env: string) {
     cy.log('Add Role ' + id);
     cy.visit(this.reqPage.path);
-    cy.contains('td', id || this.id)
-      .parent()
-      .click();
+
+    cy.contains('td', id, { timeout: 10000 }).parent().click().scrollIntoView();
+
     cy.get(this.reqPage.tabTechDetails).click();
     cy.get(this.reqPage.tabRoleManagement).click();
     if (env === 'dev') {
@@ -613,11 +605,8 @@ class Request {
   addUsertoRole(id: string, role: string, env: string, user: string): boolean {
     cy.log('Add User to Role ' + id);
     cy.visit(this.reqPage.path);
-    cy.contains('td', id || this.id, { timeout: 10000 }).scrollIntoView();
-    cy.contains('td', id || this.id, { timeout: 10000 }).should('be.visible');
-    cy.contains('td', id || this.id)
-      .parent()
-      .click();
+
+    cy.contains('td', id, { timeout: 10000 }).parent().click().scrollIntoView();
 
     if (this.authType === 'service-account') {
       cy.get('#rc-tabs-1-tab-service-account-role-management', { timeout: 10000 }).click();
@@ -650,11 +639,9 @@ class Request {
   createCompositeRole(id: string, role_main: string, role_second: string, env: string): boolean {
     cy.log('Add Composite Role ' + id);
     cy.visit(this.reqPage.path);
-    cy.contains('td', id || this.id).scrollIntoView();
-    cy.contains('td', id || this.id, { timeout: 10000 }).should('be.visible');
-    cy.contains('td', id || this.id)
-      .parent()
-      .click();
+
+    cy.contains('td', id, { timeout: 10000 }).parent().click().scrollIntoView();
+
     cy.get(this.reqPage.tabTechDetails).click();
     cy.get(this.reqPage.tabRoleManagement)
       .click()
@@ -712,9 +699,9 @@ class Request {
   removeRole(id: string, role: string, env: string): boolean {
     cy.log('Remove Role ' + id);
     cy.visit(this.reqPage.path);
-    cy.contains('td', id || this.id).scrollIntoView();
-    cy.contains('td', id || this.id, { timeout: 10000 }).should('be.visible');
-    cy.contains('td', id).parent().click();
+
+    cy.contains('td', id, { timeout: 10000 }).parent().click().scrollIntoView();
+
     cy.get(this.reqPage.tabTechDetails).click();
     cy.get(this.reqPage.tabRoleManagement)
       .click()
@@ -737,9 +724,9 @@ class Request {
 
   searchUser(id: string, environment: string, idp: string, criterion: string, error: boolean, search_value: string) {
     cy.visit(this.reqPage.path);
-    cy.contains('td', id || this.id).scrollIntoView();
-    cy.contains('td', id || this.id, { timeout: 10000 }).should('be.visible');
-    cy.contains('td', id).parent().click();
+
+    cy.contains('td', id, { timeout: 10000 }).parent().click().scrollIntoView();
+
     cy.get(this.reqPage.tabUserRoleManagement).click();
     cy.wait(2000);
     cy.get(this.reqPage.tabUserRoleManagement).then(() => {
@@ -760,9 +747,9 @@ class Request {
 
   searchIdim(id: string, environment: string, idp: string, criterion: string, error: boolean, search_value: string) {
     cy.visit(this.reqPage.path);
-    cy.contains('td', id || this.id).scrollIntoView();
-    cy.contains('td', id || this.id, { timeout: 10000 }).should('be.visible');
-    cy.contains('td', id).parent().click();
+
+    cy.contains('td', id, { timeout: 10000 }).parent().click().scrollIntoView();
+
     cy.get(this.reqPage.tabUserRoleManagement).click();
     cy.wait(2000);
     cy.get(this.reqPage.tabUserRoleManagement).then(() => {
@@ -805,84 +792,6 @@ class Request {
           });
       });
     });
-  }
-
-  viewRequest(id: string): boolean {
-    cy.log('View Request: ' + id);
-    cy.visit(this.reqPage.path);
-    // identify first column
-    cy.get(this.reqPage.integrationsTable).each(($elm, index, $list) => {
-      // text captured from column1
-      let t = $elm.text();
-      // matching criteria
-      if (t.includes(id)) {
-        cy.get(this.reqPage.integrationsTableStatus)
-          .eq(index)
-          .then(($status) => {
-            cy.log($status.text());
-            cy.get(this.reqPage.integrationsTable).eq(index).scrollIntoView();
-            if ($status.text().includes('Completed')) {
-              cy.get(this.reqPage.editButton).eq(index).click();
-            } else {
-              cy.log('Request is not in Completed status.  Cannot view/edit.');
-              return false;
-            }
-          });
-        cy.log(index.toString());
-      }
-    });
-    cy.get('h1').contains('Editing Req ID: ' + id + ' - Enter requester information');
-
-    // Tab 1
-    cy.get('[data-testid="stage-1"]').click();
-    cy.get('legend[data-testid="root_projectName_title"]').should('be.visible');
-    cy.get('#root_projectName').should('be.visible');
-    cy.get('legend[data-testid="root_usesTeam_title"]').should('be.visible');
-    cy.get(this.reqPage.usesTeam).should('be.visible');
-    cy.get('#root_teamId').should('be.visible');
-    cy.get('legend[data-testid="root_usesTeam_title"]').should('be.visible');
-    cy.get('label').contains('Create a New Team (optional)').should('be.visible');
-    cy.get('div[data-testid="form-btns"] > button[type="button"]').contains('Cancel').should('be.visible');
-    cy.get('button').contains('Next').should('be.visible');
-    cy.get('button').contains('Next').click();
-
-    // Tab 2
-    cy.get('[data-testid="stage-2"]').click();
-    cy.get('legend[data-testid="root_protocol_title"]').should('be.visible');
-    cy.get('legend[data-testid="root_authType_title"]').should('be.visible');
-    cy.get('legend[data-testid="root_publicAccess_title"]').should('be.visible');
-    cy.get('legend[data-testid="root_devIdps_title"]').should('be.visible');
-    cy.get('legend[data-testid="root_environments_title"]').should('be.visible');
-    cy.get('legend[data-testid="root_additionalRoleAttribute_title"]').should('be.visible');
-    cy.get('#root_additionalRoleAttribute').should('be.visible');
-    cy.get('div[data-testid="form-btns"] > button[type="button"]').contains('Cancel').should('be.visible');
-    cy.get('button').contains('Next').should('be.visible');
-    cy.get('button').contains('Next').click();
-
-    // Tab 3
-    cy.get('[data-testid="stage-3"]').click();
-    cy.get('legend[data-testid="root_devLoginTitle_title"]').should('be.visible');
-    cy.get('#root_devLoginTitle').should('be.visible');
-    cy.get('legend[data-testid="root_devDisplayHeaderTitle_title"]').should('be.visible');
-    cy.get('#root_devDisplayHeaderTitle').should('be.visible');
-    cy.get('legend').contains('Redirect URIs').should('be.visible');
-    cy.get('#root_devValidRedirectUris_0').should('be.visible');
-    cy.get('legend').contains('Additional Settings (Optional)').should('be.visible');
-    cy.get('div[data-testid="form-btns"] > button[type="button"]').contains('Cancel').should('be.visible');
-    cy.get('button').contains('Next').should('be.visible');
-    cy.get('button').contains('Next').click();
-
-    // Tab 4
-    cy.get('[data-testid="stage-4"]').click();
-    cy.get('#root').should('be.visible');
-    cy.get('div[data-testid="form-btns"] > button[type="button"]').contains('Update').should('be.visible');
-    cy.get('div[data-testid="form-btns"] > button[type="button"]').contains('Cancel').should('be.visible');
-
-    // Cancel Transaction
-    cy.get('div[data-testid="form-btns"] > button[type="button"]').contains('Cancel').click();
-
-    cy.visit('/my-dashboard'); // return to dashboard
-    return true;
   }
 
   // Tools

--- a/testing/cypress/appActions/Request.ts
+++ b/testing/cypress/appActions/Request.ts
@@ -5,7 +5,7 @@ import TeamPage from '../pageObjects/teamPage';
 import Utilities from '../appActions/Utilities';
 let util = new Utilities();
 
-const regex = new RegExp('@[0-9]{4,8}');
+const regex = new RegExp('@[0-9]{8}');
 
 // IDP Mapping
 const idpMap: any = {

--- a/testing/cypress/appActions/Team.ts
+++ b/testing/cypress/appActions/Team.ts
@@ -83,9 +83,13 @@ class Team {
         if (this.teamNameNew !== '') {
           cy.get('table').eq(0).click();
           cy.contains('td', this.teamNameNew, { timeout: 10000 }).parent().click({ force: true });
+          cy.contains('td', this.teamNameNew, { timeout: 10000 }).parent().click({ force: true });
+          cy.wait(2000);
         } else {
           cy.get('table').eq(0).click();
           cy.contains('td', this.teamName, { timeout: 10000 }).parent().click({ force: true });
+          cy.contains('td', this.teamName, { timeout: 10000 }).parent().click({ force: true });
+          cy.wait(2000);
         }
         let n = 0;
         while (this.deleteUser.length > n) {
@@ -107,8 +111,10 @@ class Team {
           if (this.teamNameNew !== '') {
             cy.get('table').eq(0).click();
             cy.contains('td', this.teamNameNew, { timeout: 10000 }).parent().click({ force: true });
+            cy.contains('td', this.teamNameNew, { timeout: 10000 }).parent().click({ force: true });
           } else {
             cy.get('table').eq(0).click();
+            cy.contains('td', this.teamName, { timeout: 10000 }).parent().click({ force: true });
             cy.contains('td', this.teamName, { timeout: 10000 }).parent().click({ force: true });
           }
           cy.wait(2000);

--- a/testing/cypress/e2e/disabled-idpstopper-030-github-bcgov-idp.cy.ts
+++ b/testing/cypress/e2e/disabled-idpstopper-030-github-bcgov-idp.cy.ts
@@ -30,10 +30,12 @@ describe('Github BCGov integration', () => {
 
   it('Blocks users outside of the organization from logging in with GitHub BCGov IDP', () => {
     cy.visit(playground.path);
+    cy.wait(2000);
     playground.fillInPlayground(
-      'https://dev.sandbox.loginproxy.gov.bc.ca/auth',
-      'standard',
+      null,
+      null,
       kebabCase(githubBCGovIDP.create.projectname) + '-' + util.getDate() + '-' + Number(Cypress.env('test')),
+      null,
     );
     playground.clickLogin();
 
@@ -45,10 +47,13 @@ describe('Github BCGov integration', () => {
   it('Allows users inside the organization to login', () => {
     // Test login on playground application
     cy.visit(playground.path);
+    cy.wait(2000);
+
     playground.fillInPlayground(
-      'https://dev.sandbox.loginproxy.gov.bc.ca/auth',
-      'standard',
+      null,
+      null,
       kebabCase(githubBCGovIDP.create.projectname) + '-' + util.getDate() + '-' + Number(Cypress.env('test')),
+      null,
     );
     playground.clickLogin();
 
@@ -91,10 +96,13 @@ describe('Github public integration', () => {
 
   it('Allows github users external to the organization to login with public github IDP', () => {
     cy.visit(playground.path);
+    cy.wait(2000);
+
     playground.fillInPlayground(
-      'https://dev.sandbox.loginproxy.gov.bc.ca/auth',
-      'standard',
+      null,
+      null,
       kebabCase(githubPublicIDP.create.projectname) + '-' + util.getDate() + '-' + Number(Cypress.env('test')),
+      null,
     );
     playground.clickLogin();
 

--- a/testing/cypress/e2e/idpstopper-010-test7-8.cy.ts
+++ b/testing/cypress/e2e/idpstopper-010-test7-8.cy.ts
@@ -4,7 +4,9 @@ import data from '../fixtures/idpstopper.json'; // The data file will drive the 
 import Request from '../appActions/Request';
 var kebabCase = require('lodash.kebabcase');
 import Utilities from '../appActions/Utilities';
+import Playground from '../pageObjects/playgroundPage';
 let util = new Utilities();
+let playground = new Playground();
 
 let testData = data;
 let tempData = data;
@@ -38,38 +40,21 @@ describe('Run IDP Stopper Test', () => {
 
       // Using the OIDC Playground to test the IDP Stopper
       it('Go to Playground', () => {
-        cy.visit('https://bcgov.github.io/keycloak-example-apps/');
-        cy.get('div').contains('Keycloak OIDC Config').click({ force: true });
+        cy.visit(playground.path);
+        cy.wait(2000);
 
-        // Need to add {enter} to the end of the input strings to get it to work, otherwise the changes are not picked up.
-        cy.get('input[name="url"]')
-          .clear()
-          .type('https://dev.sandbox.loginproxy.gov.bc.ca/auth' + '{enter}');
+        playground.fillInPlayground(
+          null,
+          null,
+          kebabCase(data.create.projectname) +
+            '-' +
+            util.getDate() +
+            '-' +
+            Number(Cypress.env(util.md5(data.create.projectname))),
+          null,
+        );
 
-        // Create client id from project name and integration id
-        cy.get('input[name="clientId"]')
-          .clear()
-          .type(
-            kebabCase(data.create.projectname) +
-              '-' +
-              util.getDate() +
-              '-' +
-              Number(Cypress.env(util.md5(data.create.projectname))) +
-              '{enter}',
-          );
-
-        cy.get('button').contains('Update').click();
-        cy.get('button').contains('Update').click();
-        cy.wait(2000); // Wait a bit because otherwise it will not pick up the value
-
-        /*       // Set options if required
-      cy.get('div').contains('Keycloak Login Options').click({ force: true });
-      // Set options - not implemented yet
-      cy.get('button').contains('Update').click();
-      cy.wait(2000); // Wait a bit because otherwise it will not pick up the value */
-
-        cy.get('button').contains('Login').click();
-        cy.wait(2000); // Wait a bit because to make sure the page is loaded
+        playground.clickLogin();
 
         // Only go here when there is more than one IDP Specified
         if (data.create.identityprovider.length > 1) {

--- a/testing/cypress/e2e/idpstopper-020-test11.cy.ts
+++ b/testing/cypress/e2e/idpstopper-020-test11.cy.ts
@@ -38,26 +38,22 @@ describe('Run IDP Stopper Test', () => {
       it('Go to Playground', () => {
         Cypress.session.clearAllSavedSessions();
         let playground = new Playground();
+
         cy.visit(playground.path);
         cy.wait(2000);
-        playground.selectConfig();
-        playground.setAuthServerUrl('https://dev.sandbox.loginproxy.gov.bc.ca/auth');
-        playground.setRealm('standard');
-        cy.log(Cypress.env(util.md5(data.create.projectname)));
-        playground.setClientId(
+
+        playground.fillInPlayground(
+          null,
+          null,
           kebabCase(data.create.projectname) +
             '-' +
             util.getDate() +
             '-' +
             Number(Cypress.env(util.md5(data.create.projectname))),
+          null,
         );
-        playground.selectConfig();
-        playground.clickUpdate();
-        cy.wait(2000); // Wait a bit because otherwise it will not pick up the value
-        playground.clickUpdate();
-        cy.wait(2000);
+
         playground.clickLogin();
-        cy.wait(2000); // Wait a bit because to make sure the page is loaded
 
         cy.log(data.create.identityprovider[0]);
         if (data.create.identityprovider[0] == 'Basic BCeID') {

--- a/testing/cypress/e2e/idpstopper-040-ssosession.cy.ts
+++ b/testing/cypress/e2e/idpstopper-040-ssosession.cy.ts
@@ -35,14 +35,12 @@ describe('KC Single Sign on session', () => {
     // Different application, different client, different IDP
     let playground = new Playground();
     cy.visit(playground.path);
-    playground.selectOptions();
-    playground.setIDPHint('bceidbasic');
-    playground.selectConfig();
-    playground.clickUpdate();
     cy.wait(2000);
-    playground.clickUpdate();
-    cy.wait(2000);
+
+    playground.fillInPlayground('https://dev.loginproxy.gov.bc.ca/auth', 'standard', 'test-client', 'bceidbasic');
+
     playground.clickLogin();
+    cy.wait(2000);
 
     // Log in with BCeID
     cy.setid('bceidbasic').then(() => {

--- a/testing/cypress/e2e/idpstopper-050-login-page-name-capitalization.cy.ts
+++ b/testing/cypress/e2e/idpstopper-050-login-page-name-capitalization.cy.ts
@@ -16,11 +16,7 @@ describe('Create Integration Requests For login page capitalization', () => {
   const request = data[0].create;
 
   // Only run the test if the smoketest flag is set and the test is a smoketest
-  let runOK = true;
-  if (Cypress.env('smoketest') && !data[0].smoketest) {
-    runOK = false;
-  }
-  if (runOK) {
+  if (util.runOk(data[0])) {
     // Create an integration with 2 or more IDPs and an ssoheaderdev with capitalization
     it(`Create ${request.projectname} (Test ID: ${request.test_id}) - ${request.description}`, () => {
       cy.setid(null).then(() => {
@@ -59,9 +55,12 @@ describe('Create Integration Requests For login page capitalization', () => {
             '{enter}',
         );
 
-      cy.get('button').contains('Update').click();
+      cy.wait(2000);
+      cy.get('button').contains('Update').click({ force: true });
       cy.wait(2000); // Wait a bit because otherwise it will not pick up the value
-      cy.get('button').contains('Update').click();
+      cy.get('button').contains('Update').click({ force: true });
+      cy.wait(2000);
+
       cy.get('button').contains('Login').click();
       cy.wait(2000); // Wait a bit because to make sure the page is loaded
 

--- a/testing/cypress/e2e/idpstopper-050-login-page-name-capitalization.cy.ts
+++ b/testing/cypress/e2e/idpstopper-050-login-page-name-capitalization.cy.ts
@@ -1,8 +1,11 @@
 import data from '../fixtures/capitalization-fixtures.json'; // The data file will drive the tests
 import Request from '../appActions/Request';
 import Utilities from '../appActions/Utilities';
+import Playground from '../pageObjects/playgroundPage';
+
 let util = new Utilities();
 let req = new Request();
+let playground = new Playground();
 var kebabCase = require('lodash.kebabcase');
 
 describe('Create Integration Requests For login page capitalization', () => {
@@ -25,43 +28,27 @@ describe('Create Integration Requests For login page capitalization', () => {
       req.showCreateContent(data[0]);
       req.populateCreateContent(data[0]);
       req.createRequest();
-      cy.log(util.md5('Create displayheader'));
-      cy.log(util.md5(request.projectname));
       cy.logout(null);
     });
 
     // Using the OIDC Playground to test the IDP Stopper
     it('Go to Playground', () => {
       console.log('Went to playground');
-      cy.visit('https://bcgov.github.io/keycloak-example-apps/');
-      cy.get('div').contains('Keycloak OIDC Config').click({ force: true });
 
-      // Need to add {enter} to the end of the input strings to get it to work, otherwise the changes are not picked up.
-      cy.get('input[name="url"]')
-        .clear()
-        .type('https://dev.sandbox.loginproxy.gov.bc.ca/auth' + '{enter}');
-
-      cy.log(util.md5(request.projectname));
-
-      // Create client id from project name and integration id
-      cy.get('input[name="clientId"]')
-        .clear()
-        .type(
-          kebabCase(request.projectname) +
-            '-' +
-            util.getDate() +
-            '-' +
-            Number(Cypress.env(util.md5(request.projectname))) +
-            '{enter}',
-        );
-
-      cy.wait(2000);
-      cy.get('button').contains('Update').click({ force: true });
-      cy.wait(2000); // Wait a bit because otherwise it will not pick up the value
-      cy.get('button').contains('Update').click({ force: true });
+      cy.visit(playground.path);
       cy.wait(2000);
 
-      cy.get('button').contains('Login').click();
+      playground.fillInPlayground(
+        null,
+        null,
+        kebabCase(request.projectname) +
+          '-' +
+          util.getDate() +
+          '-' +
+          Number(Cypress.env(util.md5(request.projectname))),
+        null,
+      );
+      playground.clickLogin();
       cy.wait(2000); // Wait a bit because to make sure the page is loaded
 
       // On the IDP Select Page, confirm the title is correctly capitalized.

--- a/testing/cypress/pageObjects/playgroundPage.ts
+++ b/testing/cypress/pageObjects/playgroundPage.ts
@@ -10,30 +10,43 @@ class PlaygroundPage {
   idpHint: string = 'input[name="idpHint"]';
   commonButton: string = 'button';
 
-  fillInPlayground = (url, realm, client) => {
+  fillInPlayground = (url, realm, client, idpHint) => {
     this.selectConfig();
     this.setAuthServerUrl(url);
     this.setRealm(realm);
     this.setClientId(client);
+    if (idpHint !== null) {
+      this.selectOptions();
+      this.setIDPHint(idpHint);
+      this.selectConfig();
+    }
     this.clickUpdate();
   };
 
   // Helper functions
   selectConfig() {
     cy.get('div').contains('Keycloak OIDC Config').click({ force: true });
+    cy.wait(2000);
   }
 
   selectOptions() {
     cy.get('div').contains('Keycloak Login Options').click({ force: true });
+    cy.wait(2000);
   }
 
-  setAuthServerUrl(url: string = 'https://dev.sandbox.loginproxy.gov.bc.ca/auth') {
+  setAuthServerUrl(url: string | null = 'https://dev.sandbox.loginproxy.gov.bc.ca/auth') {
+    // Check if url is null and set the default value if it is
+    url = url === null ? 'https://dev.sandbox.loginproxy.gov.bc.ca/auth' : url;
+
     cy.get(this.authServerUrl)
       .clear()
       .type(url + '{enter}');
   }
 
-  setRealm(realm: string = 'standard') {
+  setRealm(realm: string | null = 'standard') {
+    // Check if realm is null and set the default value if it is
+    realm = realm === null ? 'standard' : realm;
+
     cy.get(this.realm)
       .clear()
       .type(realm + '{enter}');
@@ -42,7 +55,10 @@ class PlaygroundPage {
   setClientId(clientId: string) {
     cy.get(this.clientId)
       .clear()
-      .type(clientId + '{enter}');
+      .type(clientId + '{enter}')
+      .then(() => {
+        cy.wait(2000);
+      });
   }
 
   setIDPHint(idpHint: string) {
@@ -52,13 +68,26 @@ class PlaygroundPage {
   }
 
   clickUpdate() {
-    cy.contains(this.commonButton, 'Update', { timeout: 10000 }).click({ force: true });
+    // Double Tap the Update button to make sure the data is loaded
+    cy.contains(this.commonButton, 'Update', { timeout: 10000 })
+      .click({ force: true })
+      .then(() => {
+        cy.wait(2000);
+      });
     cy.wait(2000); // Wait a bit because to make sure the data is loaded
+    cy.contains(this.commonButton, 'Update', { timeout: 10000 })
+      .click()
+      .then(() => {
+        cy.wait(2000);
+      });
   }
 
   clickLogin() {
-    cy.contains(this.commonButton, 'Login', { timeout: 10000 }).click({ force: true });
-    cy.wait(2000); // Wait a bit because to make sure the page is loaded
+    cy.contains(this.commonButton, 'Login', { timeout: 10000 })
+      .click({ force: true })
+      .then(() => {
+        cy.wait(2000);
+      });
   }
 
   clickLogout() {

--- a/testing/waitforconnection.sh
+++ b/testing/waitforconnection.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# max_attempts=3
-# wait_time=15
-# url=https://api-biohubbc.apps.silver.devops.gov.bc.ca/version
-# code=200
+max_attempts=3
+wait_time=15
+url=https://bcgov.github.io/sso-requests-sandbox
+code=301
 if [ $(curl --output /dev/null --silent --head -X GET --retry ${max_attempts} --fail --retry-all-errors --retry-delay ${wait_time} --retry-max-time 240 -w "%{response_code}\n" ${url}) -eq ${code} ]; then
 	echo "Connection Success!"
 else


### PR DESCRIPTION
Concurrent running of many tests causes issue with the test execution due to the mechanism was chosen to find the id of the integration that actions need to be performed on. I changed that mechanism into something that is is more resistent.