### PR TITLE
fix: same request id on update

### DIFF
--- a/testing/cypress/e2e/ci/create-integration.cy.ts
+++ b/testing/cypress/e2e/ci/create-integration.cy.ts
@@ -28,15 +28,13 @@ describe('Create Integration Requests', () => {
 
   testData.forEach((data, i) => {
     if (util.runOk(data)) {
+      let req = new Request();
       it(`Creates ${data.create.projectname} (Test ID: ${data.create.test_id}) - ${data.create.description}`, () => {
-        let req = new Request();
         req.populateCreateContent(data);
         req.createRequest();
       });
 
       it(`Updates ${data.create.projectname} (Test ID: ${data.create.test_id}) - ${data.create.description}`, () => {
-        let req = new Request();
-        req.populateCreateContent(data);
         req.updateRequest(req.id);
       });
     }


### PR DESCRIPTION
explicitly use same request instance for CI test instead of recreating from same dataset. This ensures the ID won't change